### PR TITLE
i105-FileChangeChecker Marks build files as changed

### DIFF
--- a/YoCode/FileImport.cs
+++ b/YoCode/FileImport.cs
@@ -17,7 +17,7 @@ namespace YoCode
             {
                 var fileinfo = di.GetFiles("*", SearchOption.AllDirectories);
 
-                AddFileInfoToList(files, fileinfo);
+                AddFileInfoToList(files, fileinfo, path);
 
                 return files;
             }
@@ -27,10 +27,20 @@ namespace YoCode
             }
         }
 
-        //Helper method to convert FileInfo[] elements to string and add them to a list 
-        public static void AddFileInfoToList(List<string> files, IEnumerable<FileInfo> fileinfo)
+        public static void AddFileInfoToList(List<string> files, IEnumerable<FileInfo> fileinfo, string path)
         {
-            files.AddRange(fileinfo.Select(fi => fi.ToString()));
+            foreach (var f in fileinfo)
+            {
+                if (FileIsNotInBuildDirectory(path, f))
+                {
+                    files.Add(f.ToString());
+                }
+            }
+        }
+
+        private static bool FileIsNotInBuildDirectory(string path, FileInfo fileinfo)
+        {
+            return !Path.GetRelativePath(path, fileinfo.DirectoryName).Contains("obj") && !Path.GetRelativePath(path, fileinfo.DirectoryName).Contains("bin");
         }
 
         public FileStream GetFileStream(string path)

--- a/YoCode/PathManager.cs
+++ b/YoCode/PathManager.cs
@@ -74,7 +74,7 @@ namespace YoCode
             var files = new List<string>();
             var di = new DirectoryInfo(PATH);
 
-            FileImport.AddFileInfoToList(files, di.GetFiles(fileExtensions[type], SearchOption.AllDirectories));
+            FileImport.AddFileInfoToList(files, di.GetFiles(fileExtensions[type], SearchOption.AllDirectories), PATH);
             return files;
         }
     }

--- a/YoCode/Program.cs
+++ b/YoCode/Program.cs
@@ -51,9 +51,6 @@ namespace YoCode
             var modifiedTestDirPath = result.modifiedFilePath;
             var originalTestDirPath = result.originalFilePath;
 
-            ProjectBuilder.CleanBuildOutput(originalTestDirPath);
-            ProjectBuilder.CleanBuildOutput(modifiedTestDirPath);
-
             var dir = new PathManager(originalTestDirPath, modifiedTestDirPath);
 
             if (dir.ModifiedPaths == null || dir.OriginalPaths == null)

--- a/YoCode/ProjectBuilder.cs
+++ b/YoCode/ProjectBuilder.cs
@@ -10,6 +10,8 @@ namespace YoCode
 
         public ProjectBuilder(string workingDir, FeatureRunner featureRunner)
         {
+            CleanBuildOutput(workingDir);
+
             ProjectBuilderEvidence.FeatureTitle = "Project build";
             var processDetails = new ProcessDetails(ProcessName, workingDir, Arguments);
 
@@ -72,7 +74,7 @@ namespace YoCode
             return numbers.Count > 0 ? numbers[0] : -1;
         }
 
-        public static void CleanBuildOutput(string workingDir)
+        private static void CleanBuildOutput(string workingDir)
         {
             var pr = new ProcessRunner("dotnet", workingDir, "clean");
             pr.ExecuteTheCheck();


### PR DESCRIPTION
reverted dotnet clean changes, modified FileImport to exclude files in bin and obj directories.