### PR TITLE
Update version number for sprint 4

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2-prerelease",
+  "version": "0.4-prerelease",
   "publicReleaseRefSpec": [
     "^refs/heads/v\\d+(?:\\.\\d+)?$"
   ],


### PR DESCRIPTION
Forgot to do it for sprint 3. It doesn't really matter because the software isn't released yet anyway, I just like things to be tidy.