### PR TITLE
I102-CodeCoverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # To run this program you will need to: #
 
 * Download CMD Tools from https://www.jetbrains.com/resharper/download/download-thanks.html?platform=windows&code=RSCLT
+* Download dotCover from https://www.jetbrains.com/dotcover/download/#section=commandline
 
 * Create appsettings.json file inside YoCode project with the following code:
 
@@ -8,6 +9,9 @@
 {
   "duplicationCheckSetup": {
     "CMDtoolsDir": "PATH TO CMD LIBRARY (..\CMD)"
+  },
+  "codeCoverageCheckSetup": {
+    "dotCoverDir": " PATH TO DOTCOVER (e.g. ...\JetBrains.dotCover.CommandLineTools.2018.1.4)"
   }
 }
 ```
@@ -16,10 +20,10 @@
 ```
 {
   "AutomatedTesting": {
-    "TestDataPath": "C:\\YoCodeTestData"
+    "TestDataPath": "PATH TO YOCODE AUTOMATED TESTS (e.g. C:\\YoCodeTestData)"
   },
   "YoCodeLocation": {
-    "DLLFolderPath":  "PATH TO FOLDER WITH YoCode.dll file (..\YoCode\YoCode\bin\Debug\netcoreapp2.1)"
+    "DLLFolderPath":  "PATH TO FOLDER WITH YoCode.dll (..\YoCode\YoCode\bin\Debug\netcoreapp2.1)"
   }
 }
 ```

--- a/YoCode/CodeCoverageCheck.cs
+++ b/YoCode/CodeCoverageCheck.cs
@@ -1,0 +1,100 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace YoCode
+{
+    internal class CodeCoverageCheck
+    {
+        private string Argument { get; }
+        private string ProcessName { get; } = "dotCover.exe";
+        private const string testFolder = "UnitConverterTests";
+        private string ReportName { get; } = "report.json";
+        private string FullReportPath { get; }
+
+        public CodeCoverageCheck(string dotCoverDir, string workingDir, string dotnetDir, FeatureRunner featureRunner)
+        {
+            CodeCoverageEvidence.FeatureTitle = "Code Coverage";
+
+            FullReportPath = Path.Combine(dotCoverDir, ReportName);
+
+            var targetWorkingDir = Path.Combine(workingDir, testFolder);
+
+            if (!Directory.Exists(targetWorkingDir))
+            {
+                CodeCoverageEvidence.SetFailed($"{testFolder} Directory Not Found");
+                return;
+            }
+
+            Argument = CreateArgument(dotnetDir, targetWorkingDir);
+
+            var evidence = featureRunner.Execute(CreateProcessDetails(dotCoverDir));
+
+            var report = ReadReport();
+            CleanUp();
+
+            var coverage = GetCodeCoverage(report);
+
+            if (coverage == 0)
+            {
+                CodeCoverageEvidence.SetFailed("Code Coverage Not Found");
+            }
+            else if(coverage == -1)
+            {
+                CodeCoverageEvidence.SetFailed("Failed to Generate/Read Report");
+            }
+            else
+            {
+                CodeCoverageEvidence.FeatureImplemented = true;
+                CodeCoverageEvidence.GiveEvidence($"Code Coverage: {coverage}%");
+            }
+        }
+
+        private string CreateArgument(string dotnetDir, string targetWorkingDir)
+        {
+            var dotnetExecutablePath = Path.Combine(dotnetDir, "dotnet.exe");
+
+            return $"analyse /TargetExecutable=\"{dotnetExecutablePath}\" /TargetArguments=\"test\" /TargetWorkingDir=\"{targetWorkingDir}\"" +
+                $" /ReportType=\"JSON\" /Output=\"{ReportName}\"";
+        }
+
+        private ProcessDetails CreateProcessDetails(string dotCoverDir)
+        {
+            var processPath = Path.Combine(dotCoverDir, ProcessName);
+
+            return new ProcessDetails(processPath, dotCoverDir, Argument);
+        }
+
+        private string ReadReport()
+        {
+            using (StreamReader sr = File.OpenText(FullReportPath))
+            {
+                return sr.ReadToEnd();
+            }
+        }
+
+        private int GetCodeCoverage(string json)
+        {
+            try
+            {
+                var coverage = JObject.Parse(json)["Children"]
+                   .Where(c => (string)c["Name"] == "UnitConverterWebApp" && (string)c["Kind"] == "Assembly")
+                   .Select(c => (int)c["CoveragePercent"]);
+
+                return coverage.FirstOrDefault();
+            }
+            catch (ArgumentNullException) { }
+            /*If YoCode times out then dotCover also fails and ArgumentNullException occurs*/
+
+            return -1;
+        }
+
+        private void CleanUp()
+        {
+            File.Delete(FullReportPath);
+        }
+
+        public FeatureEvidence CodeCoverageEvidence { get; } = new FeatureEvidence();
+    }
+}

--- a/YoCode/CodeCoverageCheck.cs
+++ b/YoCode/CodeCoverageCheck.cs
@@ -13,7 +13,7 @@ namespace YoCode
         private string ReportName { get; } = "report.json";
         private string FullReportPath { get; }
 
-        public CodeCoverageCheck(string dotCoverDir, string workingDir, string dotnetDir, FeatureRunner featureRunner)
+        public CodeCoverageCheck(string dotCoverDir, string workingDir, FeatureRunner featureRunner)
         {
             CodeCoverageEvidence.FeatureTitle = "Code Coverage";
 
@@ -27,7 +27,7 @@ namespace YoCode
                 return;
             }
 
-            Argument = CreateArgument(dotnetDir, targetWorkingDir);
+            Argument = CreateArgument("C:\\Program Files\\dotnet", targetWorkingDir);
 
             var evidence = featureRunner.Execute(CreateProcessDetails(dotCoverDir));
 

--- a/YoCode/Program.cs
+++ b/YoCode/Program.cs
@@ -11,7 +11,9 @@ namespace YoCode
     {
         public static IConfiguration Configuration;
 
-        static string CMDToolsPath;
+        private static string CMDToolsPath;
+        private static string dotCoverDir;
+        private static string dotnetDir;
 
         static void Main(string[] args)
         {
@@ -24,6 +26,8 @@ namespace YoCode
                 var builder = new ConfigurationBuilder().SetBasePath(Directory.GetCurrentDirectory()).AddJsonFile("appsettings.json");
                 Configuration = builder.Build();
                 CMDToolsPath = Configuration["duplicationCheckSetup:CMDtoolsDir"];
+                dotCoverDir = Configuration["codeCoverageCheckSetup:dotCoverDir"];
+                dotnetDir = Configuration["dotnetSetup:dotnetexeDir"];
             }
             catch (FileNotFoundException)
             {
@@ -64,7 +68,7 @@ namespace YoCode
                 compositeOutput.ShowLaziness();
                 return;
             }
-            
+
             var implementedFeatureList = PerformChecks(dir);
             compositeOutput.PrintFinalResults(implementedFeatureList.OrderBy(a=>a.FeatureTitle));
         }
@@ -123,6 +127,8 @@ namespace YoCode
                 checkList.Add(ucc.UnitConverterCheckEvidence);
 
                 checkList.Add(ucc.BadInputCheckEvidence);
+
+                checkList.Add(new CodeCoverageCheck(dotCoverDir, dir.modifiedTestDirPath, dotnetDir, new FeatureRunner()).CodeCoverageEvidence);
 
                 dupFinderThread.Join();
                 pr.KillProject();

--- a/YoCode/Program.cs
+++ b/YoCode/Program.cs
@@ -13,7 +13,6 @@ namespace YoCode
 
         private static string CMDToolsPath;
         private static string dotCoverDir;
-        private static string dotnetDir;
 
         static void Main(string[] args)
         {
@@ -27,7 +26,6 @@ namespace YoCode
                 Configuration = builder.Build();
                 CMDToolsPath = Configuration["duplicationCheckSetup:CMDtoolsDir"];
                 dotCoverDir = Configuration["codeCoverageCheckSetup:dotCoverDir"];
-                dotnetDir = Configuration["dotnetSetup:dotnetexeDir"];
             }
             catch (FileNotFoundException)
             {
@@ -128,7 +126,8 @@ namespace YoCode
 
                 checkList.Add(ucc.BadInputCheckEvidence);
 
-                checkList.Add(new CodeCoverageCheck(dotCoverDir, dir.modifiedTestDirPath, dotnetDir, new FeatureRunner()).CodeCoverageEvidence);
+                //Code Coverage
+                checkList.Add(new CodeCoverageCheck(dotCoverDir, dir.modifiedTestDirPath, new FeatureRunner()).CodeCoverageEvidence);
 
                 dupFinderThread.Join();
                 pr.KillProject();


### PR DESCRIPTION
Note: this check increased YoCode's run time to about 35 seconds so possibly will need to run in a separate thread. #102 

To run YoCode now you'll need to:
1. Download dotCover: https://www.jetbrains.com/dotcover/download/#section=commandline
2. append appsettings.json with two additional paths:

```
 "codeCoverageCheckSetup": {
    "dotCoverDir": "Path to directory containing dotCover.exe"
  },
  "dotnetSetup": {
    "dotnetexeDir": "Path to directory containing dotnet.exe (usually "C:\\Program Files\\dotnet")"
  }
```