### PR TITLE
CrashWithWatersCommit

### DIFF
--- a/YoCode/GitCheck.cs
+++ b/YoCode/GitCheck.cs
@@ -50,7 +50,7 @@ namespace YoCode
         {
             const string RFC2822Format = "ddd dd MMM HH:mm:ss yyyy K";
 
-            foreach (Commit c in commitLog)
+            foreach (Commit c in commitLog.Where(c => !c.Author.Email.ContainsAny(GetHostDomains())))
             {
                 output.Add(string.Format("commit {0}", c.Id));
 
@@ -66,7 +66,7 @@ namespace YoCode
             return string.Join(Environment.NewLine, output);
         }
 
-        public bool LastCommitWasByNonEmployee(IQueryableCommitLog c)
+        public static bool LastCommitWasByNonEmployee(IQueryableCommitLog c)
         {
             return !c.First().Author.Email.ContainsAny(GetHostDomains());
         }

--- a/YoCode/Output/WebWriter.cs
+++ b/YoCode/Output/WebWriter.cs
@@ -1,20 +1,17 @@
-﻿using System;
-using System.IO;
-using System.Collections.Generic;
+﻿using System.IO;
 using System.Text;
-using System.Linq;
 
 namespace YoCode
 {
     public class WebWriter : IPrint
     {
-        const string OUTPUT_PATH = @"YoCodeReport.html";
-        const string FEATURE_TAG = "{FEATURE}";
-        const string SCORE_TAG = "{SCORE}";
+        private const string OUTPUT_PATH = "YoCodeReport.html";
+        private const string FEATURE_TAG = "{FEATURE}";
+        private const string SCORE_TAG = "{SCORE}";
 
-        StringBuilder features;
-        StringBuilder errors;
-        StringBuilder msg;
+        private readonly StringBuilder features;
+        private readonly StringBuilder errors;
+        private readonly StringBuilder msg;
 
         private double score;
 
@@ -63,26 +60,10 @@ namespace YoCode
 
         public void WriteReport()
         {
-            var writeTo = (Program.OutputTo!=null)? Path.Combine(Program.OutputTo, OUTPUT_PATH) : OUTPUT_PATH;
-
-            var consoleWriter = new ConsoleWriter();
-            try
+            File.WriteAllText(OUTPUT_PATH, BuildReport());
+            if (Program.OpenHTMLOnFinish)
             {
-                if (Program.GenerateHtml)
-                {
-                    File.WriteAllText(writeTo, BuildReport());
-                    if (Program.OpenHTMLOnFinish)
-                    {
-                        HtmlReportLauncher.LaunchReport(OUTPUT_PATH);
-                    }
-                    consoleWriter.AddMessage(String.Format(messages.SuccessfullyWroteReport, Environment.NewLine, Path.GetFullPath(writeTo)));
-                    consoleWriter.WriteReport();
-                }
-            }
-            catch
-            {
-                
-                consoleWriter.PrintErrors(new List<string>() { String.Format(messages.WrongWritePermission, Path.GetFullPath(writeTo), Environment.NewLine, Environment.NewLine) });
+                HtmlReportLauncher.LaunchReport(OUTPUT_PATH);
             }
         }
     }

--- a/YoCode/Output/WebWriter.cs
+++ b/YoCode/Output/WebWriter.cs
@@ -1,17 +1,20 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace YoCode
 {
     public class WebWriter : IPrint
     {
-        private const string OUTPUT_PATH = "YoCodeReport.html";
-        private const string FEATURE_TAG = "{FEATURE}";
-        private const string SCORE_TAG = "{SCORE}";
+        const string OUTPUT_PATH = @"YoCodeReport.html";
+        const string FEATURE_TAG = "{FEATURE}";
+        const string SCORE_TAG = "{SCORE}";
 
-        private readonly StringBuilder features;
-        private readonly StringBuilder errors;
-        private readonly StringBuilder msg;
+        StringBuilder features;
+        StringBuilder errors;
+        StringBuilder msg;
 
         private double score;
 
@@ -60,10 +63,26 @@ namespace YoCode
 
         public void WriteReport()
         {
-            File.WriteAllText(OUTPUT_PATH, BuildReport());
-            if (Program.OpenHTMLOnFinish)
+            var writeTo = (Program.OutputTo!=null)? Path.Combine(Program.OutputTo, OUTPUT_PATH) : OUTPUT_PATH;
+
+            var consoleWriter = new ConsoleWriter();
+            try
             {
-                HtmlReportLauncher.LaunchReport(OUTPUT_PATH);
+                if (Program.GenerateHtml)
+                {
+                    File.WriteAllText(writeTo, BuildReport());
+                    if (Program.OpenHTMLOnFinish)
+                    {
+                        HtmlReportLauncher.LaunchReport(OUTPUT_PATH);
+                    }
+                    consoleWriter.AddMessage(String.Format(messages.SuccessfullyWroteReport, Environment.NewLine, Path.GetFullPath(writeTo)));
+                    consoleWriter.WriteReport();
+                }
+            }
+            catch
+            {
+                
+                consoleWriter.PrintErrors(new List<string>() { String.Format(messages.WrongWritePermission, Path.GetFullPath(writeTo), Environment.NewLine, Environment.NewLine) });
             }
         }
     }

--- a/YoCode/Output/WebWriter.cs
+++ b/YoCode/Output/WebWriter.cs
@@ -1,18 +1,20 @@
 ﻿using System;
 using System.IO;
+using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace YoCode
 {
     public class WebWriter : IPrint
     {
-        private const string OUTPUT_PATH = "YoCodeReport.html";
-        private const string FEATURE_TAG = "{FEATURE}";
-        private const string SCORE_TAG = "{SCORE}";
+        const string OUTPUT_PATH = @"YoCodeReport.html";
+        const string FEATURE_TAG = "{FEATURE}";
+        const string SCORE_TAG = "{SCORE}";
 
-        private readonly StringBuilder features;
-        private readonly StringBuilder errors;
-        private readonly StringBuilder msg;
+        StringBuilder features;
+        StringBuilder errors;
+        StringBuilder msg;
 
         private double score;
 
@@ -56,8 +58,7 @@ namespace YoCode
                 return messages.HtmlTemplate_HelpPage.Replace(FEATURE_TAG, msg.ToString());
             }
 
-            return messages.HtmlTemplate.Replace(FEATURE_TAG, features.Append(msg).ToString())
-                .Replace(SCORE_TAG, (!Double.IsNaN(score)) ? score + "%" : "0%");
+            return messages.HtmlTemplate.Replace(FEATURE_TAG, features.Append(msg).ToString()).Replace(SCORE_TAG, score + "%");
         }
 
         public void WriteReport()

--- a/YoCode/Output/WebWriter.cs
+++ b/YoCode/Output/WebWriter.cs
@@ -1,20 +1,18 @@
 ﻿using System;
 using System.IO;
-using System.Collections.Generic;
 using System.Text;
-using System.Linq;
 
 namespace YoCode
 {
     public class WebWriter : IPrint
     {
-        const string OUTPUT_PATH = @"YoCodeReport.html";
-        const string FEATURE_TAG = "{FEATURE}";
-        const string SCORE_TAG = "{SCORE}";
+        private const string OUTPUT_PATH = "YoCodeReport.html";
+        private const string FEATURE_TAG = "{FEATURE}";
+        private const string SCORE_TAG = "{SCORE}";
 
-        StringBuilder features;
-        StringBuilder errors;
-        StringBuilder msg;
+        private readonly StringBuilder features;
+        private readonly StringBuilder errors;
+        private readonly StringBuilder msg;
 
         private double score;
 
@@ -36,7 +34,7 @@ namespace YoCode
             featureResults.Append(WebElementBuilder.FormatParagraph(data.featureResult));
             featureResults.Append(WebElementBuilder.FormatListOfStrings(data.evidence));
 
-            var featureTitle = WebElementBuilder.FormaFeatureTitle(data.title,data.featurePass,data.score);
+            var featureTitle = WebElementBuilder.FormaFeatureTitle(data.title, data.featurePass, data.score);
 
             features.Append(WebElementBuilder.FormatAccordionElement(featureTitle, featureResults.ToString()));
         }
@@ -58,7 +56,8 @@ namespace YoCode
                 return messages.HtmlTemplate_HelpPage.Replace(FEATURE_TAG, msg.ToString());
             }
 
-            return messages.HtmlTemplate.Replace(FEATURE_TAG, features.Append(msg).ToString()).Replace(SCORE_TAG, score+"%");
+            return messages.HtmlTemplate.Replace(FEATURE_TAG, features.Append(msg).ToString())
+                .Replace(SCORE_TAG, (!Double.IsNaN(score)) ? score + "%" : "0%");
         }
 
         public void WriteReport()

--- a/YoCode/Program.cs
+++ b/YoCode/Program.cs
@@ -47,8 +47,8 @@ namespace YoCode
 
             showLoadingAnim = !result.NoLoadingScreen;
             var implementedFeatureList = PerformChecks(dir, parameters);
+
             compositeOutput.PrintFinalResults(implementedFeatureList.OrderBy(a => a.FeatureTitle), new Results(implementedFeatureList, TestType.Junior).FinalScore);
-            pr.ReportLefOverProcess();
         }
 
         public static bool OpenHTMLOnFinish { get; set; }
@@ -62,7 +62,13 @@ namespace YoCode
             // Files changed check
             checkList.Add(fileCheck.FileChangeEvidence);
 
-            if (fileCheck.FileChangeEvidence.Evidence.Contains("No Files Changed"))
+            var stopEvidence = new List<string>()
+            {
+                "No Files Changed",
+                "Last Commit By Waters Employee"
+            };
+
+            if (fileCheck.FileChangeEvidence.Evidence.ListContainsAnyKeywords(stopEvidence))
             {
                 return checkList;
             }
@@ -134,6 +140,7 @@ namespace YoCode
             workThreads.ForEach(a => a.Join());
             pr.KillProject();
 
+            pr.ReportLefOverProcess();
             return checkList;
         }
     }

--- a/YoCode/Results.cs
+++ b/YoCode/Results.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace YoCode
 {
-    class Results
+    internal class Results
     {
         public double FinalScore { get; set; }
         public double MaximumScore { get; set;}
@@ -47,19 +46,21 @@ namespace YoCode
 
         public void ApplySpecialCases(List<FeatureEvidence> list)
         {
-            double badInputWeighting = 0;
-
-            badInputWeighting = list.Find(e => e.Feature == Feature.BadInputCheck && e.FeatureRating == 0)?.FeatureWeighting ?? 0;
-            list.Find(e => e.Feature == Feature.FrontEndCheck).FeatureWeighting = badInputWeighting;
-
-            var unitConverterCheck = list.Find(e => e.Feature == Feature.UnitConverterCheck);
-
-            if (unitConverterCheck.FeatureFailed)
+            if (list.Count > 1)
             {
-                MaximumScore -= unitConverterCheck.FeatureWeighting;
-                unitConverterCheck.FeatureWeighting = 0;
-            }
+                double badInputWeighting = 0;
 
+                badInputWeighting = list.Find(e => e.Feature == Feature.BadInputCheck && e.FeatureRating == 0)?.FeatureWeighting ?? 0;
+                list.Find(e => e.Feature == Feature.FrontEndCheck).FeatureWeighting = badInputWeighting;
+
+                var unitConverterCheck = list.Find(e => e.Feature == Feature.UnitConverterCheck);
+
+                if (unitConverterCheck.FeatureFailed)
+                {
+                    MaximumScore -= unitConverterCheck.FeatureWeighting;
+                    unitConverterCheck.FeatureWeighting = 0;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
#171 
FileChangeFinder now properly disposes of the Repository object and correctly displays staged(uncommited) files. Added a new check to see if the last commit was made by a Waters employee. GitCheck now only displays commits made by non employees. YoCode now exits instantly if it finds that the last commit was by a waters employee and there are no untracked and uncommited files 