### PR TITLE
i220-ReportBug

### DIFF
--- a/YoCode/FeatureRunner.cs
+++ b/YoCode/FeatureRunner.cs
@@ -4,7 +4,7 @@
     {
         private ProcessRunner pr;
 
-        public FeatureEvidence Execute(ProcessDetails processDetails, string waitForMessage = null, bool kill =true)
+        public FeatureEvidence Execute(ProcessDetails processDetails, string waitForMessage = null, bool kill = true)
         {
             pr = new ProcessRunner(processDetails.ProcessName, processDetails.WorkingDir, processDetails.Arguments);
             pr.ExecuteTheCheck(waitForMessage, kill);

--- a/YoCode/ProcessRunner.cs
+++ b/YoCode/ProcessRunner.cs
@@ -141,8 +141,6 @@ namespace YoCode
         {
             if (!p.HasExited)
             {
-                // TODO: Refactor Process Runner
-                // Try/Catch needed to catch exceptions when process cannot be killed
                 try
                 {
                     p.Kill();

--- a/YoCode/Program.cs
+++ b/YoCode/Program.cs
@@ -44,8 +44,8 @@ namespace YoCode
                 else
                 {
                     compositeOutput.ShowHelp();
+                    LaunchReport(result, outputPath);
                 }
-                LaunchReport(result, outputPath);
                 return;
             }
 

--- a/YoCode/ProjectRunner.cs
+++ b/YoCode/ProjectRunner.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 
 namespace YoCode
 {
-    // TODO: find other way of running .dll file instead of hardcoding the name 
     internal class ProjectRunner : ICheck
     {
         internal string Output { get; set; }
@@ -45,7 +44,6 @@ namespace YoCode
                 Output = evidence.Output;
                 ErrorOutput = evidence.ErrorOutput;
 
-                // TODO: Refactor Project Runner
                 const string portKeyword = "Now listening on: ";
                 var line = Output.GetLineWithOneKeyword(portKeyword);
                 var splitLine = line.Split(portKeyword, StringSplitOptions.None);
@@ -105,7 +103,11 @@ namespace YoCode
 
         public void ReportLefOverProcess()
         {
-            featureRunner.FindLeftOverProcess();
+            try
+            {
+                featureRunner.FindLeftOverProcess();
+            }
+            catch (NullReferenceException) { }
         }
     }
 }


### PR DESCRIPTION
YoCode doesn't open the HTML report if it encountered run parameter errors. Handled NullReferenceException in "ReportLeftOverProcess"
#220 