### PR TITLE
Remove equivalent feature weightings from json

### DIFF
--- a/YoCode/FeatureWeightings/JuniorWeightings.json
+++ b/YoCode/FeatureWeightings/JuniorWeightings.json
@@ -4,11 +4,8 @@
   "CodeCoverageCheck": 1.32,
   "TestDuplicationCheck": 0,
   "AppDuplicationCheck": 1.69,
-  "UICodeCheck": 1.03,
   "FilesChangedCheck": 0,
   "GitCheck": 1,
   "UnitConverterCheck": 1.09,
   "UIFeatureImplemented": 0,
-  "UIBadInputCheck": 0,
-  "UIConversionCheck": 0
 }

--- a/YoCode/FeatureWeightings/OriginalWeightings.json
+++ b/YoCode/FeatureWeightings/OriginalWeightings.json
@@ -4,11 +4,8 @@
   "CodeCoverageCheck": 1.32,
   "TestDuplicationCheck": 0,
   "AppDuplicationCheck": 1.69,
-  "UICodeCheck": 1.03,
   "FilesChangedCheck": 0,
   "GitCheck": 1,
   "UnitConverterCheck": 1.09,
   "UIFeatureImplemented": 0,
-  "UIBadInputCheck": 1.2,
-  "UIConversionCheck": 1.09
 }

--- a/YoCode/Results.cs
+++ b/YoCode/Results.cs
@@ -19,7 +19,11 @@ namespace YoCode
 
         private static void AssignWeightings(List<FeatureEvidence> list, IReadOnlyDictionary<Feature, double> xTestDetails)
         {
-            list.ForEach(e => e.FeatureWeighting = xTestDetails[e.Feature]);
+            foreach (var x in xTestDetails)
+            {
+                list.Find(e => e.Feature == x.Key).FeatureWeighting = x.Value;
+            }
+
         }
 
         public void CalculateWeightedRatings(List<FeatureEvidence> list)
@@ -27,7 +31,7 @@ namespace YoCode
             ApplySpecialCases(list);
 
             foreach (var elem in list)
-            {                
+            {
                 elem.WeightedRating = Math.Round(elem.FeatureRating * elem.FeatureWeighting, 2);
                 MaximumScore += elem.FeatureWeighting;
                 FinalScore += elem.WeightedRating;
@@ -63,13 +67,13 @@ namespace YoCode
 
         public void AssignToEquivalentCheck(FeatureEvidence oldCheck,FeatureEvidence newCheck)
         {
+            newCheck.FeatureWeighting = oldCheck.FeatureWeighting;
+
             if (oldCheck.Inconclusive)
             {
                 newCheck.FeatureWeighting = oldCheck.FeatureWeighting * 2 ;
                 oldCheck.FeatureWeighting = 0;
             }
         }
-
-
     }
 }


### PR DESCRIPTION
Pretty sure there could be a way to avoid that foreach loop and use LINQ functions? but not sure how