### PR TITLE
Deliberately removing exception handling

### DIFF
--- a/YoCode/DotCover.cs
+++ b/YoCode/DotCover.cs
@@ -32,22 +32,14 @@ namespace YoCode
 
         public static int CalculateCoverageFromJsonReport(string json)
         {
-            try
-            {
-                var coverageReport = JsonConvert.DeserializeObject<ReportRoot>(json);
+            var coverageReport = JsonConvert.DeserializeObject<ReportRoot>(json);
 
-                var webAppAssembly = coverageReport.Children.Single(c => c.Kind == "Assembly" && c.Name == "UnitConverterWebApp");
-                var allTypesInWebapp = webAppAssembly.Children.SelectMany(n => n.Children.Where(c => c.Kind == "Type"));
-                var filteredTypesInWebApp = allTypesInWebapp.Where(t => t.Name != "Program" && t.Name != "Startup").ToList();
-                var totalRelevantStatements = filteredTypesInWebApp.Sum(t => t.TotalStatements);
-                var coveredRelevantStatements = filteredTypesInWebApp.Sum(t => t.CoveredStatements);
-                return (int)(coveredRelevantStatements * 100.0 / totalRelevantStatements);
-            }
-            catch (ArgumentNullException) { }
-            catch (JsonReaderException) { }
-            catch (JsonSerializationException) { }
-
-            return -1;
+            var webAppAssembly = coverageReport.Children.Single(c => c.Kind == "Assembly" && c.Name == "UnitConverterWebApp");
+            var allTypesInWebapp = webAppAssembly.Children.SelectMany(n => n.Children.Where(c => c.Kind == "Type"));
+            var filteredTypesInWebApp = allTypesInWebapp.Where(t => t.Name != "Program" && t.Name != "Startup").ToList();
+            var totalRelevantStatements = filteredTypesInWebApp.Sum(t => t.TotalStatements);
+            var coveredRelevantStatements = filteredTypesInWebApp.Sum(t => t.CoveredStatements);
+            return (int)(coveredRelevantStatements * 100.0 / totalRelevantStatements);
         }
     }
 }


### PR DESCRIPTION
I want the automated tests to crash if any of these problems occur. I think at the moment the tests are getting `-1` for the coverage but I can't tell which error caused it, so I need them to fail more spectacularly.